### PR TITLE
Added Windows install instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 extramuros - language-neutral shared-buffer networked live coding system
 ==========
 
-See install-osx.md for installation instructions.  See this document for usage.
+See install-osx.md and install-win.md for installation instructions.  See this document for usage.
 
 The big picture: This is software for collaborative live coding.  On one machine, you run an extramuros "server".  Then, from as many machines as you like, you use a web browser to connect to the server and code into shared text buffers.  Finally, and again from as many machines as you like, your run the extramuros "client" code in order to receive code from the server and pipe it to the language interpreter of your choice (SuperCollider, Tidal, etc).  Think of the "client" code as a way for machines to listen in on a public stream of code.
 

--- a/install-win.md
+++ b/install-win.md
@@ -1,0 +1,22 @@
+## extramuros installation instructions (Windows 8)
+
+While this install will likely work on Windows XP, Vista, and 7, it has not 
+been tested on these systems.
+
+1. Install prerequisites to build the `node-gyp` package on your version of 
+Windows. Follow the instructions at https://github.com/TooTallNate/node-gyp. 
+
+2. Clone the extramuros repository:
+
+```
+git clone https://github.com/d0kt0r0/extramuros.git
+```
+
+3. Use npm (node package manager, installed with node) to install the node 
+packages required by extramuros:
+```
+cd extramuros
+npm install
+```
+
+That's it for installation - now you are ready to test and play! (see README.md)


### PR DESCRIPTION
I got extramuros working on Win8. `npm install` just works, as long as the `node-gyp` package pre-requisites are installed (Python, and a flavor of Visual Studio). This is all documented in the new `install-win.md`. 

Tested the server and client with Tidal and it worked great.