### PR TITLE
add superdirt boot option and custom Tidal startup file cmd line option

### DIFF
--- a/.ghciSuperDirt
+++ b/.ghciSuperDirt
@@ -1,0 +1,17 @@
+import Sound.Tidal.Context
+
+(cps,getNow) <- bpsUtils
+
+(d1,t1) <- superDirtSetters getNow
+(d2,t2) <- superDirtSetters getNow
+(d3,t3) <- superDirtSetters getNow
+(d4,t4) <- superDirtSetters getNow
+(d5,t5) <- superDirtSetters getNow
+(d6,t6) <- superDirtSetters getNow
+(d7,t7) <- superDirtSetters getNow
+(d8,t8) <- superDirtSetters getNow
+(d9,t9) <- superDirtSetters getNow
+
+let bps x = cps (x/2)
+let hush = mapM_ ($ silence) [d1,d2,d3,d4,d5,d6,d7,d8,d9]
+let solo = (>>) hush

--- a/client.js
+++ b/client.js
@@ -96,19 +96,19 @@ var withTidalVisuals = parsed['tidalVisuals'];
 var withTidalSuperDirt = parsed['tidalSuperDirt'];
 if(withTidal!=null && typeof withTidal!="boolean") { // custom tidal boot file provided
   if(withTidalVisuals!=true || withTidalSuperDirt!=true) {
-    stderr.write("Error: Too many arguments provided for Tidal boot options");
+    stderr.write("Error: Too many arguments provided for Tidal boot options\n");
     System.exit(1);
   }
   else {
     try{ fs.accessSync(withTidal, fs.F_OK); }
     catch (e) { 
-      stderr.write("Error: Tidal boot file does not exist"); 
+      stderr.write("Error: Tidal boot file does not exist\n"); 
       System.exit(1);
     }
   }
 }
 if(withTidalVisuals==true && withTidalSuperDirt==true) {
-  stderr.write("Error: Cannot boot SuperDirt with visuals enabled");
+  stderr.write("Error: Cannot boot SuperDirt with visuals enabled\n");
   System.exit(1);
 }
 if(withTidalVisuals!=null || withTidalSuperDirt!=null) { withTidal = true; }

--- a/client.js
+++ b/client.js
@@ -5,6 +5,7 @@ var zmq = require('zmq');
 var WebSocket = require('ws');
 var osc = require('osc');
 var fs = require('fs');
+var path = require('path');
 
 // some global variables
 var stderr = process.stderr;
@@ -23,8 +24,10 @@ var knownOpts = {
     "password" : [String, null],
     "help": Boolean,
     "feedback": Boolean,
-    "tidal": Boolean,
+    "tidal": [Boolean, path],
     "tidalVisuals": Boolean,
+    "tidalSuperDirt": Boolean,
+    //"tidalCustom": path,
     "newlines-as-spaces" : Boolean
 };
 
@@ -35,6 +38,8 @@ var shortHands = {
     "o" : ["--osc-port"],
     "w" : ["--ws-port"],
     "p" : ["--password"],
+    "t" : ["--tidal"],
+    //"c" : ["--tidalCustom"],
     "h" : ["--help"],
     "f" : ["--feedback"]
 };
@@ -43,16 +48,19 @@ var parsed = nopt(knownOpts,shortHands,process.argv,2);
 
 if(parsed['help']!=null) {
     stderr.write("extramuros client.js usage:\n");
-    stderr.write(" --help (-h)               this help message\n");
-    stderr.write(" --server (-s) [address]   address of server's downstream (default:localhost)\n");
-    stderr.write(" --zmq-port (-z) [number]  TCP port on which to connect to server (default: 8001)\n");
-    stderr.write(" --ws-port [number]        port for OSC WebSocket connection to server (default: 8002)\n");
-    stderr.write(" --osc-port [number]       UDP port on which to receive OSC messages (default: none)\n");
-    stderr.write(" --password [word] (-p)    password to authenticate messages to server\n");
-    stderr.write(" --feedback (-f)           send feedback from stdin to server\n");
-    stderr.write(" --tidal                   launch Tidal (ghci) and use its stdout as feedback\n");
-    stderr.write(" --tidalVisuals            launch Tidal (ghci) with .ghciVisuals\n");
-    stderr.write(" --newlines-as-spaces (-n) converts any received newlines to spaces on stdout\n");
+    stderr.write(" --help (-h)                this help message\n");
+    stderr.write(" --server (-s) [address]    address of server's downstream (default:localhost)\n");
+    stderr.write(" --zmq-port (-z) [number]   TCP port on which to connect to server (default: 8001)\n");
+    stderr.write(" --ws-port [number]         port for OSC WebSocket connection to server (default: 8002)\n");
+    stderr.write(" --osc-port [number]        UDP port on which to receive OSC messages (default: none)\n");
+    stderr.write(" --password [word] (-p)     password to authenticate messages to server\n");
+    stderr.write(" --feedback (-f)            send feedback from stdin to server\n");
+    stderr.write(" --tidal (-t) [address]     launch Tidal (ghci) and use its stdout as feedback with\n"+
+                 "                            standard options or custom bootfile (default: .ghciNoVisuals)\n");
+    stderr.write(" --tidalVisuals             launch Tidal (ghci) with .ghciVisuals\n");
+    stderr.write(" --tidalSuperDirt           launch Tidal (ghci) with .ghciSuperDirt\n");
+    //stderr.write(" --tidalCustom (-c) [path]  provide a custom boot script for Tidal (ghci)\n");
+    stderr.write(" --newlines-as-spaces (-n)  converts any received newlines to spaces on stdout\n");
     process.exit(1);
 }
 
@@ -85,7 +93,25 @@ if(oscPort!=null && password == null) {
 
 var withTidal = parsed['tidal'];
 var withTidalVisuals = parsed['tidalVisuals'];
-if(withTidalVisuals!=null) { withTidal = true; }
+var withTidalSuperDirt = parsed['tidalSuperDirt'];
+if(withTidal!=null && typeof withTidal!="boolean") { // custom tidal boot file provided
+  if(withTidalVisuals!=true || withTidalSuperDirt!=true) {
+    stderr.write("Error: Too many arguments provided for Tidal boot options");
+    System.exit(1);
+  }
+  else {
+    try{ fs.accessSync(withTidal, fs.F_OK); }
+    catch (e) { 
+      stderr.write("Error: Tidal boot file does not exist"); 
+      System.exit(1);
+    }
+  }
+}
+if(withTidalVisuals==true && withTidalSuperDirt==true) {
+  stderr.write("Error: Cannot boot SuperDirt with visuals enabled");
+  System.exit(1);
+}
+if(withTidalVisuals!=null || withTidalSuperDirt!=null) { withTidal = true; }
 
 var child;
 var tidal;
@@ -103,8 +129,10 @@ if(withTidal != null) {
       defaultFeedbackFunction(m.toString());
     });
     var dotGhci;
-    if(withTidalVisuals == null) { dotGhci = ".ghciNoVisuals"; }
-    else { dotGhci = ".ghciVisuals"; }
+    if(typeof withTidal!="boolean") { dotGhci = withTidal; }
+    else if(withTidalSuperDirt != null) { dotGhci = ".ghciSuperDirt"; }
+    else if(withTidalVisuals != null) { dotGhci = ".ghciVisuals"; }
+    else { dotGhci = ".ghciNoVisuals"; }
     fs.readFile(dotGhci,'utf8', function (err,data) {
       if (err) { console.log(err); return; }
       tidal.stdin.write(data);

--- a/client.js
+++ b/client.js
@@ -130,8 +130,8 @@ if(withTidal != null) {
     });
     var dotGhci;
     if(withCustomTidalBoot != null) { dotGhci = withCustomTidalBoot; }
-    else if(withTidalSuperDirt != null) { dotGhci = ".ghciSuperDirt"; }
-    else if(withTidalVisuals != null) { dotGhci = ".ghciVisuals"; }
+    else if(withTidalSuperDirt == true) { dotGhci = ".ghciSuperDirt"; }
+    else if(withTidalVisuals == true) { dotGhci = ".ghciVisuals"; }
     else { dotGhci = ".ghciNoVisuals"; }
     fs.readFile(dotGhci,'utf8', function (err,data) {
       if (err) { console.log(err); return; }

--- a/client.js
+++ b/client.js
@@ -48,18 +48,18 @@ var parsed = nopt(knownOpts,shortHands,process.argv,2);
 
 if(parsed['help']!=null) {
     stderr.write("extramuros client.js usage:\n");
-    stderr.write(" --help (-h)                  this help message\n");
-    stderr.write(" --server (-s) [address]      address of server's downstream (default:localhost)\n");
-    stderr.write(" --zmq-port (-z) [number]     TCP port on which to connect to server (default: 8001)\n");
-    stderr.write(" --ws-port [number]           port for OSC WebSocket connection to server (default: 8002)\n");
-    stderr.write(" --osc-port [number]          UDP port on which to receive OSC messages (default: none)\n");
-    stderr.write(" --password [word] (-p)       password to authenticate messages to server\n");
-    stderr.write(" --feedback (-f)              send feedback from stdin to server\n");
-    stderr.write(" --tidal (-t) [address]       launch Tidal (ghci) and use its stdout as feedback with\n");
-    stderr.write(" --tidalVisuals               launch Tidal (ghci) with .ghciVisuals\n");
-    stderr.write(" --tidalSuperDirt             launch Tidal (ghci) with .ghciSuperDirt\n");
-    stderr.write(" --tidalCustom [address] (-T) launch Tidal (ghci) with custom startup file\n");
-    stderr.write(" --newlines-as-spaces (-n)    converts any received newlines to spaces on stdout\n");
+    stderr.write(" --help (-h)                 this help message\n");
+    stderr.write(" --server (-s) [address]     address of server's downstream (default:localhost)\n");
+    stderr.write(" --zmq-port (-z) [number]    TCP port on which to connect to server (default: 8001)\n");
+    stderr.write(" --ws-port [number]          port for OSC WebSocket connection to server (default: 8002)\n");
+    stderr.write(" --osc-port [number]         UDP port on which to receive OSC messages (default: none)\n");
+    stderr.write(" --password [word] (-p)      password to authenticate messages to server\n");
+    stderr.write(" --feedback (-f)             send feedback from stdin to server\n");
+    stderr.write(" --tidal (-t)                launch Tidal (ghci) and use its stdout as feedback with\n");
+    stderr.write(" --tidalVisuals              launch Tidal (ghci) with .ghciVisuals\n");
+    stderr.write(" --tidalSuperDirt            launch Tidal (ghci) with .ghciSuperDirt\n");
+    stderr.write(" --tidalCustom (-T) filename launch Tidal (ghci) with custom startup file\n");
+    stderr.write(" --newlines-as-spaces (-n)   converts any received newlines to spaces on stdout\n");
     process.exit(1);
 }
 
@@ -97,19 +97,19 @@ var withCustomTidalBoot = parsed['tidalCustom'];
 if(withCustomTidalBoot!=null) {                      // custom tidal boot file provided
   if(withTidalVisuals==true || withTidalSuperDirt==true) {
     stderr.write("Error: Too many arguments provided for Tidal boot options\n");
-    System.exit(1);
+    process.exit(1);
   }
   else {
     try{ fs.accessSync(withCustomTidalBoot, fs.F_OK); }
     catch (e) { 
      stderr.write("Error: Tidal boot file does not exist\n"); 
-     System.exit(1);
+     process.exit(1);
     }
   }
 }
 if(withTidalVisuals==true && withTidalSuperDirt==true) {
   stderr.write("Error: Cannot boot SuperDirt with visuals enabled\n");
-  System.exit(1);
+  process.exit(1);
 }
 if(withTidalVisuals!=null || withTidalSuperDirt!=null || withCustomTidalBoot!=null) { withTidal = true; }
 


### PR DESCRIPTION
++ File: `.ghciSuperDirt` automatically sets synth streams (d1-9 & t1-9) with superDirtSetters
++ Cmd line option `--tidalSuperDirt` in style similar to `--tidalVisuals`. Cannot use SuperDirt and Visuals together, else error.
++ Shorthand alias for `--tidal (-t)`
++ Cmd line option `--tidalCustom (-T) filename` takes the filename and path to a custom Tidal boot script. This allows customization of startup without altering the included .ghci* files. This option flags Tidal to start without also calling `--tidal`. Will throw error and exit if `--tidalSuperDirt` or `--tidalVisuals` are also flagged.